### PR TITLE
fix(constructor): fetch correct env variable, undefined check

### DIFF
--- a/src/utils/xmlConstructorSimple.js
+++ b/src/utils/xmlConstructorSimple.js
@@ -149,9 +149,9 @@ async function construct54XMLSimple(trackData) {
         soundSetInfo.push(soundSets)
     }
 
-    let soundset = process.env.soundset;
+    let soundset = process.env.npm_config_soundset;
 
-    if (soundset === null) {
+    if (soundset === null || soundset === undefined) {
         soundset = 'special_soundset'
     }
 


### PR DESCRIPTION
- soundset param wasn't being passed to the xml constructor properly
- soundset when not specified could be undefined and not null, this accounts for that.